### PR TITLE
Adding IQuery.GetBatchAsync method that retrieves a batch with given size

### DIFF
--- a/examples/AccountApi/Controllers/AccountsController.cs
+++ b/examples/AccountApi/Controllers/AccountsController.cs
@@ -24,6 +24,12 @@ namespace AccountApi.Controllers
         {
             return _accountService.ReadAsync(cancellationToken);
         }
+        
+        [HttpGet("batch/{batchSize}")]
+        public Task<IEnumerable<Account>> GetBatchAsync(int batchSize, CancellationToken cancellationToken)
+        {
+            return _accountService.ReadBatchAsync(batchSize, cancellationToken);
+        }
 
         [HttpGet("{id}")]
         [ProducesResponseType(typeof(Account), 200)]

--- a/examples/AccountApi/Services/AccountService.cs
+++ b/examples/AccountApi/Services/AccountService.cs
@@ -49,6 +49,12 @@ namespace AccountApi.Services
             var response = await _query.GetAsync<Account>("Select Id, Name From Account", cancellationToken);
             return response?.Records ?? Enumerable.Empty<Account>();
         }
+        
+        public async Task<IEnumerable<Account>> ReadBatchAsync(int batchSize, CancellationToken cancellationToken)
+        {
+            var response = await _query.GetBatchAsync<Account>("Select Id, Name From Account", batchSize, cancellationToken);
+            return response?.Records ?? Enumerable.Empty<Account>();
+        }
 
         public async Task<Account> ReadAsync(string id, CancellationToken cancellationToken)
         {

--- a/examples/AccountApi/Services/IAccountService.cs
+++ b/examples/AccountApi/Services/IAccountService.cs
@@ -13,5 +13,6 @@ namespace AccountApi.Services
         Task UpdateAsync(string id, AccountUpdate account, CancellationToken cancellationToken);
         Task UpdateAsync(IEnumerable<Account> accounts, CancellationToken cancellationToken);
         Task<IEnumerable<Account>> GetCompositeAsync(IEnumerable<string> ids, CancellationToken cancellationToken);
+        Task<IEnumerable<Account>> ReadBatchAsync(int batchSize, CancellationToken cancellationToken);
     }
 }

--- a/src/Reinforce/RestApi/IQuery.cs
+++ b/src/Reinforce/RestApi/IQuery.cs
@@ -28,6 +28,16 @@ namespace Reinforce.RestApi
             CancellationToken cancellationToken = default,
             [Path] string version = Api.Version
         );
+        
+        [Get("/services/data/{version}/query")]
+        [Header("Authorization", "Bearer")]
+        Task<QueryResponse<TSObject>> GetBatchAsync<TSObject>(
+            [Query] string q,
+            [Header("Sforce-Query-Options", Format="batchSize={0}")] int batchSize,
+            CancellationToken cancellationToken = default,
+            [Path] string version = Api.Version
+        );
+
 
         [Get("/services/data/{version}/query/{queryIdentifier}")]
         [Header("Authorization", "Bearer")]

--- a/version.json
+++ b/version.json
@@ -12,5 +12,5 @@
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"
   ],
-  "version": "2.0"
+  "version": "2.1"
 }


### PR DESCRIPTION
Adding IQuery.GetBatchAsync method that retrieves a batch which size is given in "Sforce-Query-Options" header. Version to 2.1